### PR TITLE
Support haskell-src-exts == 1.17.*

### DIFF
--- a/SourceGraph.cabal
+++ b/SourceGraph.cabal
@@ -81,5 +81,5 @@ Executable SourceGraph {
                         Graphalyze >= 0.14.1.0 && < 0.15,
                         graphviz >= 2999.15.0.0 && < 2999.19,
                         Cabal == 1.22.*,
-                        haskell-src-exts == 1.16.*
+                        haskell-src-exts == 1.17.*
 }


### PR DESCRIPTION
There were some API change on haskell-src-exts 1.17, specifically:
- https://github.com/haskell-suite/haskell-src-exts/commit/b0527bfe44902a2f885ca34ba471b21a0c99f780
- https://github.com/haskell-suite/haskell-src-exts/commit/b4f471c6c4bd521d0868d14ae9d793138d4e97a2
- https://github.com/haskell-suite/haskell-src-exts/commit/d1c979ad555d245086d8eb8147df0d1117f9c184

Because of those commits, master was failing with:

```
Parsing/ParseModule.hs:118:15:
    Constructor ‘IVar’ should have 1 argument, but has been given 2
    In the pattern: IVar _ n
    In an equation for ‘createEnt’:
        createEnt mn (IVar _ n) = [Ent mn (nameOf n) NormalEntity]

Parsing/ParseModule.hs:134:18:
    Constructor ‘IVar’ should have 1 argument, but has been given 2
    In the pattern: IVar _ n
    In an equation for ‘listedEnt’:
        listedEnt _ el (IVar _ n) = [lookupEntity' el $ nameOf n]

Parsing/ParseModule.hs:167:18:
    Constructor ‘EVar’ should have 1 argument, but has been given 2
    In the pattern: EVar _ qn
    In an equation for ‘listedExp’:
        listedExp _ el (EVar _ qn)
          = maybe [] (return . lookupEntity el) $ qName qn

Parsing/ParseModule.hs:489:65:
    Couldn't match expected type ‘Binds’ with actual type ‘Maybe Binds’
    In the first argument of ‘getBindings’, namely ‘bs’
    In a stmt of a 'do' block: (bds, bcs) <- getBindings bs

Parsing/ParseModule.hs:571:56:
    Couldn't match expected type ‘Binds’ with actual type ‘Maybe Binds’
    In the first argument of ‘getBindings’, namely ‘bs’
    In a stmt of a 'do' block: (bd, bc) <- getBindings bs

Parsing/ParseModule.hs:673:53:
    Couldn't match expected type ‘Binds’ with actual type ‘Maybe Binds’
    In the first argument of ‘getBindings’, namely ‘bs’
```

I tried to patch the source and managed to get it compile, but I'm not familiar with either SourceGraph 
or haskell-src-exts; so I only tweaked until it type-checked. So, can you review and merge if everything
looks okay? I'm specifically unsure about first parameters of `noDefs` calls.

Thanks.
